### PR TITLE
bench?

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,58 @@
+name: bench
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  benchee:
+    runs-on: ubuntu-latest
+
+    env:
+      MIX_ENV: bench
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: simplecastapps/rust-device-detector
+          path: rust-device-detector
+
+      - id: beam
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: 1
+          otp-version: 27
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: bench-${{ steps.beam.outputs.elixir-version }}-${{ github.head_ref || github.ref }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            bench-${{ steps.beam.outputs.elixir-version }}-${{ github.head_ref || github.ref }}-
+            bench-${{ steps.beam.outputs.elixir-version }}-refs/heads/master-
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            rust-device-detector/target
+            ~/.cargo
+          key: rust-${{ github.head_ref || github.ref }}-${{ hashFiles('rust-device-detector/Cargo.lock') }}
+          restore-keys: |
+            rust-${{ github.head_ref || github.ref }}-
+            rust-refs/heads/master-
+
+      - run: cargo build --release --features=build-binary
+        working-directory: rust-device-detector
+
+      - run: mix deps.get --only $MIX_ENV
+      - run: mix compile --warnings-as-errors
+      - run: mix ua_inspector.download --force
+      - run: mix run bench/ua.exs
+        env:
+          RUST_DETECTOR_PATH: ./rust-device-detector/target/release/rust-device-detector

--- a/bench/ua.exs
+++ b/bench/ua.exs
@@ -17,5 +17,5 @@ Benchee.run(
     "100 random from devices.txt" => Enum.take_random(devices, 100),
     "all devices.txt" => Enum.shuffle(devices)
   },
-  parallel: 4
+  parallel: System.schedulers()
 )


### PR DESCRIPTION
```
Operating System: Linux
CPU Information: AMD EPYC 7763 64-Core Processor
Number of Available Cores: 4
Available memory: 15.62 GB
Elixir 1.18.3
Erlang 27.3
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 0 ns
reduction time: 0 ns
parallel: 4
inputs: 10 random from devices.txt, 100 random from devices.txt, all devices.txt
Estimated total run time: 42 s

Benchmarking elixir with input 10 random from devices.txt ...
Benchmarking elixir with input 100 random from devices.txt ...
Benchmarking elixir with input all devices.txt ...
Benchmarking rust port with input 10 random from devices.txt ...
Rust says: Starting interactive mode
Rust says: Starting interactive mode
Rust says: Starting interactive mode
Rust says: Starting interactive mode
Benchmarking rust port with input 100 random from devices.txt ...
Rust says: Starting interactive mode
Rust says: Starting interactive mode
Rust says: Starting interactive mode
Rust says: Starting interactive mode
Benchmarking rust port with input all devices.txt ...
Rust says: Starting interactive mode
Rust says: Starting interactive mode
Rust says: Starting interactive mode
Rust says: Starting interactive mode
Calculating statistics...
Formatting results...

##### With input 10 random from devices.txt #####
Name                ips        average  deviation         median         99th %
rust port         18.34       54.53 ms    ±60.27%       51.16 ms      360.92 ms
elixir             1.73      576.79 ms    ±15.35%      537.17 ms      815.94 ms

Comparison: 
rust port         18.34
elixir             1.73 - 10.58x slower +522.26 ms

##### With input 100 random from devices.txt #####
Name                ips        average  deviation         median         99th %
rust port          1.65         0.61 s    ±11.88%         0.60 s         0.80 s
elixir            0.163         6.14 s     ±0.39%         6.15 s         6.16 s

Comparison: 
rust port          1.65
elixir            0.163 - 10.11x slower +5.53 s

##### With input all devices.txt #####
Name                ips        average  deviation         median         99th %
rust port        0.0826        12.11 s     ±5.10%        12.20 s        12.69 s
elixir           0.0169        59.11 s     ±0.10%        59.12 s        59.17 s

Comparison: 
rust port        0.0826
elixir           0.0169 - 4.88x slower +47.01 s
```